### PR TITLE
Update autopep8.yml

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -30,7 +30,14 @@ jobs:
         run: |
           autopep8 --in-place --aggressive --recursive .
 
+      # Check if any files have changed after running autopep8
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git diff --exit-code || echo "Changes detected"
+
       - name: Commit and push changes
+        if: steps.check_changes.outputs.changed == 'true'
         run: |
           git config --global user.name "autopep8-bot"
           git config --global user.email "autopep8-bot@fake-addr-dont-email-me.sjtu.edu.cn"
@@ -38,4 +45,3 @@ jobs:
           git commit -m "Fix PEP 8 issues [no ci]"
 
           git push
-        if: ${{ success() }}


### PR DESCRIPTION
This step checks for changes that need to be committed to avoid CI failure.
> If there are no changes (the working tree is clean), this step will output 'No changes to commit.' and exit early to prevent the workflow from failing.